### PR TITLE
Fix example GitHub url

### DIFF
--- a/content/troubleshooting/build-performance.md
+++ b/content/troubleshooting/build-performance.md
@@ -17,7 +17,7 @@ toc: true
 ---
 
 {{% note %}}
-The example site used below is from https://github.com/gohugoio/hugo/examples/blog
+The example site used below is from https://github.com/gohugoio/hugo/tree/master/examples/blog
 {{% /note %}}
 
 ## Template Metrics


### PR DESCRIPTION
The repository url currently does not contain the `tree/master` path, so that it return a *404* error.